### PR TITLE
Add get-tls-cert command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "pem-rfc7468",
  "rcgen",
  "reqwest",
  "rustls-pemfile",
@@ -216,6 +217,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bindgen"
@@ -985,6 +992,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4.5.51", features = ["derive"] }
 webpki-roots = "1.0.4"
 rustls-pemfile = "2.2.0"
 anyhow = "1.0.100"
+pem-rfc7468 = { version = "0.7.0", features = ["std"] }
 
 [dev-dependencies]
 rcgen = "0.14.5"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 This is a work-in-progress crate designed to be an alternative to [`cvm-reverse-proxy`](https://github.com/flashbots/cvm-reverse-proxy).
 
-It offers two components:
-- a proxy server, which accepts TLS connections from a proxy client, sends an attestation and then forwards traffic to a target CVM service.
-- a proxy client, which accepts connections from elsewhere, connects to and verifies the attestation from the proxy server, and then forwards traffic to it over TLS.
+It has three commands:
+- `server` - run a proxy server, which accepts TLS connections from a proxy client, sends an attestation and then forwards traffic to a target CVM service.
+- `client` - run a proxy client, which accepts connections from elsewhere, connects to and verifies the attestation from the proxy server, and then forwards traffic to it over TLS.
+- `get-tls-cert` - connects to a proxy-server, verify the attestation, and if successful write the server's PEM-encoded TLS certificate chain to standard out. This can be used to make subsequent connections to services using this certificate over regular TLS.
 
 Unlike `cvm-reverse-proxy`, this uses post-handshake remote-attested TLS, meaning regular CA-signed TLS certificates can be used.
 


### PR DESCRIPTION
This adds a command to get the TLS certificate from a `ProxyServer` instance if its attestation can be validated.

If successful it writes the certificate chain to standard output as PEM.

This is designed to be used the same way the `attested-get` command from `cvm-reverse-proxy` is used - it allows us the get the cert chain so that it can be used in subsequent non-attested connections to another service using this certificate.