### PR TITLE
Rm uneeded field from Cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "attested-tls-proxy"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
-license-file = "LICENSE"
 
 [dependencies]
 tokio = { version = "1.48.0", features = ["full"]}


### PR DESCRIPTION
The compiler complains about there being both license and license-file fields 