### PR TITLE
Improve logic for test DCAP verification

### DIFF
--- a/src/attestation/mod.rs
+++ b/src/attestation/mod.rs
@@ -285,12 +285,19 @@ impl AttestationVerifier {
                 .await?
             }
             _ => {
-                dcap::verify_dcap_attestation(
-                    attestation_exchange_message.attestation,
-                    expected_input_data,
-                    self.pccs_url.clone(),
-                )
-                .await?
+                if cfg!(test) {
+                    dcap::mock_verify_dcap(
+                        attestation_exchange_message.attestation,
+                        expected_input_data,
+                    )?
+                } else {
+                    dcap::verify_dcap_attestation(
+                        attestation_exchange_message.attestation,
+                        expected_input_data,
+                        self.pccs_url.clone(),
+                    )
+                    .await?
+                }
             }
         };
 


### PR DESCRIPTION
Without this, we were mocking DCAP verification when testing azure attestations against a pre-generated attestation.

In order to be able to test the v6 override PR, i needed to change this.