### PR TITLE
Allow giving measurement file as url, and improve measurement checking logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ use attested_tls_proxy::{
 struct Cli {
     #[clap(subcommand)]
     command: CliCommand,
-    /// Optional path to file containing JSON measurements to be enforced on the remote party
+    /// Path to file, or URL, containing JSON measurements to be enforced on the remote party
     #[arg(long, global = true, env = "MEASUREMENTS_FILE")]
-    measurements_file: Option<PathBuf>,
+    measurements_file: Option<String>,
     /// If no measurements file is specified, a single attestion type to allow
     #[arg(long, global = true)]
     allowed_remote_attestation_type: Option<String>,
@@ -171,7 +171,9 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let measurement_policy = match cli.measurements_file {
-        Some(server_measurements) => MeasurementPolicy::from_file(server_measurements).await?,
+        Some(server_measurements) => {
+            MeasurementPolicy::from_file_or_url(server_measurements).await?
+        }
         None => {
             let allowed_server_attestation_type: AttestationType = serde_json::from_value(
                 serde_json::Value::String(cli.allowed_remote_attestation_type.ok_or(anyhow!(


### PR DESCRIPTION
This allows giving the accepted measurements JSON as a URL, as cvm-reverse-proxy also offers this.  

A tests is added which retrieves the public buildernet measurement values from a URL, and ensures they parse correctly. 

It also slightly improves the measurement checking logic, as when testing it was found that if specific measurement registers are unspecified, they don't need to match the policy.  In practice this should not be a big issue as our attestation validation code should ensure the necessary registers are present.  But i think it is important to be strict when checking measurements anyway.

Closes https://github.com/flashbots/attested-tls-proxy/issues/59