### PR TITLE
Validate XFAM values using a bitmask

### DIFF
--- a/src/attestation/azure/mod.rs
+++ b/src/attestation/azure/mod.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use x509_parser::prelude::*;
 
-use crate::attestation::{dcap::verify_dcap_attestation, measurements::MultiMeasurements};
+use crate::attestation::{
+    dcap::verify_dcap_attestation_with_given_timestamp, measurements::MultiMeasurements,
+};
 
 /// The attestation evidence payload that gets sent over the channel
 #[derive(Debug, Serialize, Deserialize)]
@@ -108,8 +110,13 @@ async fn verify_azure_attestation_with_given_timestamp(
 
     // Do DCAP verification
     let tdx_quote_bytes = BASE64_URL_SAFE.decode(attestation_document.tdx_quote_base64)?;
-    let _dcap_measurements =
-        verify_dcap_attestation(tdx_quote_bytes, expected_tdx_input_data, pccs_url).await?;
+    let _dcap_measurements = verify_dcap_attestation_with_given_timestamp(
+        tdx_quote_bytes,
+        expected_tdx_input_data,
+        pccs_url,
+        now,
+    )
+    .await?;
 
     let hcl_ak_pub = hcl_report.ak_pub()?;
 


### PR DESCRIPTION
This ports XFAM validation from this (currently unmerged) PR to cvm-reverse-proxy: https://github.com/flashbots/cvm-reverse-proxy/pull/48

Note that unlike the PR linked above, this does NOT introduce MRSEAM validation.

Currently, this will always check the value complies with the policy mask, regardless of platform.  This works with our observed values from GCP and Azure which are used in tests.

But it may not work with some bare metal configurations or if Google/Microsoft change their cloud configuration in the future.

So it could be worth using different masks for different platforms.  I will not merge this until we get agreement on what the policy should be here. 

Closes https://github.com/flashbots/attested-tls/issues/43