### PR TITLE
Accept hostnames as target server for proxy server

### DIFF
--- a/src/attested_get.rs
+++ b/src/attested_get.rs
@@ -81,7 +81,7 @@ mod tests {
             cert_chain,
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::new_not_dummy(AttestationType::DcapTdx).unwrap(),
             AttestationVerifier::expect_none(),
         )

--- a/src/file_server.rs
+++ b/src/file_server.rs
@@ -18,7 +18,7 @@ pub async fn attested_file_server(
     let server = ProxyServer::new(
         cert_and_key,
         listen_addr,
-        target_addr,
+        target_addr.to_string(),
         attestation_generator,
         attestation_verifier,
         client_auth,
@@ -103,7 +103,7 @@ mod tests {
             cert_chain,
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::new_not_dummy(AttestationType::DcapTdx).unwrap(),
             AttestationVerifier::expect_none(),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,15 @@ pub struct ProxyServer {
     attested_tls_server: AttestedTlsServer,
     /// The underlying TCP listener
     listener: Arc<TcpListener>,
-    /// The address of the target service we are proxying to
-    target: SocketAddr,
+    /// The address/hostname of the target service we are proxying to
+    target: String,
 }
 
 impl ProxyServer {
     pub async fn new(
         cert_and_key: TlsCertAndKey,
         local: impl ToSocketAddrs,
-        target: SocketAddr,
+        target: String,
         attestation_generator: AttestationGenerator,
         attestation_verifier: AttestationVerifier,
         client_auth: bool,
@@ -97,7 +97,7 @@ impl ProxyServer {
         cert_chain: Vec<CertificateDer<'static>>,
         server_config: Arc<ServerConfig>,
         local: impl ToSocketAddrs,
-        target: SocketAddr,
+        target: String,
         attestation_generator: AttestationGenerator,
         attestation_verifier: AttestationVerifier,
     ) -> Result<Self, ProxyError> {
@@ -120,7 +120,7 @@ impl ProxyServer {
 
     /// Accept an incoming connection and handle it in a seperate task
     pub async fn accept(&self) -> Result<(), ProxyError> {
-        let target = self.target;
+        let target = self.target.clone();
         let (inbound, _client_addr) = self.listener.accept().await?;
         let attested_tls_server = self.attested_tls_server.clone();
 
@@ -153,7 +153,7 @@ impl ProxyServer {
         tls_stream: tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
         measurements: Option<MultiMeasurements>,
         remote_attestation_type: AttestationType,
-        target: SocketAddr,
+        target: String,
     ) -> Result<(), ProxyError> {
         tracing::debug!("proxy-server accepted connection");
 
@@ -183,6 +183,7 @@ impl ProxyServer {
                     .expect("Attestation type should be able to be encoded as a header value"),
             );
 
+            let target = target.clone();
             async move {
                 match Self::handle_http_request(req, target).await {
                     Ok(res) => {
@@ -208,7 +209,7 @@ impl ProxyServer {
     // Handle a request from the proxy client to the target server
     async fn handle_http_request(
         req: hyper::Request<hyper::body::Incoming>,
-        target: SocketAddr,
+        target: String,
     ) -> Result<Response<BoxBody<bytes::Bytes, hyper::Error>>, ProxyError> {
         // Connect to the target server
         let outbound = TcpStream::connect(target).await?;
@@ -595,7 +596,7 @@ mod tests {
             cert_chain,
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::new_not_dummy(AttestationType::DcapTdx).unwrap(),
             AttestationVerifier::expect_none(),
         )
@@ -672,7 +673,7 @@ mod tests {
             server_cert_chain,
             server_tls_server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::with_no_attestation(),
             AttestationVerifier::mock(),
         )
@@ -743,7 +744,7 @@ mod tests {
             server_cert_chain,
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::with_no_attestation(),
             AttestationVerifier::mock(),
         )
@@ -824,7 +825,7 @@ mod tests {
             server_cert_chain,
             server_tls_server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::new_not_dummy(AttestationType::DcapTdx).unwrap(),
             AttestationVerifier::mock(),
         )
@@ -923,7 +924,7 @@ mod tests {
             cert_chain.clone(),
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::new_not_dummy(AttestationType::DcapTdx).unwrap(),
             AttestationVerifier::expect_none(),
         )
@@ -960,7 +961,7 @@ mod tests {
             cert_chain,
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::with_no_attestation(),
             AttestationVerifier::expect_none(),
         )
@@ -1004,7 +1005,7 @@ mod tests {
             cert_chain,
             server_config,
             "127.0.0.1:0",
-            target_addr,
+            target_addr.to_string(),
             AttestationGenerator::new_not_dummy(AttestationType::DcapTdx).unwrap(),
             AttestationVerifier::expect_none(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,8 @@ enum CliCommand {
         /// Socket address to listen on
         #[arg(short, long, default_value = "0.0.0.0:0", env = "LISTEN_ADDR")]
         listen_addr: SocketAddr,
-        /// Socket address of the target service to forward traffic to
-        target_addr: SocketAddr,
+        /// The hostname:port or ip:port of the target service to forward traffic to
+        target_addr: String,
         /// Type of attestation to present (dafaults to 'auto' for automatic detection)
         /// If other than None, a TLS key and certicate must also be given
         #[arg(long, env = "SERVER_ATTESTATION_TYPE")]


### PR DESCRIPTION
This allow the target service which a proxy server communicates with to be referred to by hostname:port rather than only ip address.