### PR TITLE
Add test demonstrating nested TLS

### DIFF
--- a/src/attested_tls.rs
+++ b/src/attested_tls.rs
@@ -505,7 +505,7 @@ fn length_prefix(input: &[u8]) -> [u8; 4] {
 }
 
 /// Given a hostname with or without port number, create a TLS [ServerName] with just the host part
-fn server_name_from_host(
+pub(crate) fn server_name_from_host(
     host: &str,
 ) -> Result<ServerName<'static>, tokio_rustls::rustls::pki_types::InvalidDnsNameError> {
     // If host contains ':', try to split off the port.


### PR DESCRIPTION
This adds a test to demonstrate that it is possible to use `AttestedTlsServer` and `AttestedTlsClient` over existing TLS streams.

That is, an outer TLS session with one TLS configuration (eg: with CA-signed certs), and an inner TLS session with another configuration (eg: with self-signed certs).