### PR TITLE
Remove the dependency on OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,6 @@ reqwest = { version = "0.12.24", default-features = false, features = [
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 parity-scale-codec = "3.7.5"
-openssl = "0.10.75"
-az-tdx-vtpm = { version = "0.7.4", optional = true }
-tss-esapi = { version = "7.6.0", optional = true }
 num-bigint = "0.4.6"
 webpki = { package = "rustls-webpki", version = "0.103.8" }
 time = "0.3.44"
@@ -55,6 +52,11 @@ p256 = { version = "0.13.2", features = ["pkcs8"] }
 pkcs1 = "0.7.5"
 pkcs8 = "0.10.2"
 rcgen = "0.14.5"
+
+# For Azure vTPM attestation
+az-tdx-vtpm = { version = "0.7.4", optional = true }
+tss-esapi = { version = "7.6.0", optional = true }
+openssl = { version = "0.10.75", optional = true }
 
 # For websockets
 tokio-tungstenite = { version = "0.28.0", optional = true }
@@ -77,7 +79,7 @@ jsonrpsee = { version = "0.26.0", features = ["server"] }
 default = ["azure", "ws", "rpc"]
 
 # Adds support for Microsoft Azure attestation generation and verification
-azure = ["tss-esapi", "az-tdx-vtpm"]
+azure = ["tss-esapi", "az-tdx-vtpm", "openssl"]
 
 # Adds websocket support
 ws = ["tokio-tungstenite", "futures-util"]


### PR DESCRIPTION
This makes it possible to compile without depending on OpenSSL by disabling default features.

OpenSSL is used by the `azure` and `rpc` feature flags.