### PR TITLE
Bump bytes to 1.11.1 due to vulnerability in previously used version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,9 +848,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -1960,7 +1960,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3062,7 +3062,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3099,7 +3099,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.3"
 hyper = { version = "1.7.0", features = ["server", "http2"] }
 hyper-util = { version = "0.1.17", features = ["tokio"] }
 http-body-util = "0.1.3"
-bytes = "1.10.1"
+bytes = "1.11.1"
 http = "1.3.1"
 serde_json = "1.0.145"
 serde = "1.0.228"


### PR DESCRIPTION
https://github.com/flashbots/attested-tls-proxy/security/dependabot/3