### PR TITLE
Make attested tls server / client constructors sync functions

### DIFF
--- a/attested-tls/README.md
+++ b/attested-tls/README.md
@@ -54,7 +54,7 @@ These are the attestation type names used in the measurements file.
 
 Local attestation types can be automatically detected.
 
-### Measurements File
+## Measurements File
 
 Accepted measurements for the remote party can be specified in a JSON file containing an array of objects, each of which specifies an accepted attestation type and set of measurements.
 

--- a/attested-tls/src/attested_rpc.rs
+++ b/attested-tls/src/attested_rpc.rs
@@ -261,7 +261,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -279,7 +278,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let attested_rpc_client = AttestedRpcClient::new_http2(client);
@@ -304,7 +302,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -334,7 +331,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let attested_rpc_client = AttestedRpcClient::new_http2(client);

--- a/attested-tls/src/lib.rs
+++ b/attested-tls/src/lib.rs
@@ -73,7 +73,7 @@ impl std::fmt::Debug for AttestedTlsServer {
 }
 
 impl AttestedTlsServer {
-    pub async fn new(
+    pub fn new(
         cert_and_key: TlsCertAndKey,
         attestation_generator: AttestationGenerator,
         attestation_verifier: AttestationVerifier,
@@ -99,13 +99,12 @@ impl AttestedTlsServer {
             attestation_generator,
             attestation_verifier,
         )
-        .await
     }
 
     /// Start with preconfigured TLS
     ///
     /// This allows dangerous configuration
-    pub async fn new_with_tls_config(
+    pub fn new_with_tls_config(
         cert_chain: Vec<CertificateDer<'static>>,
         mut server_config: ServerConfig,
         attestation_generator: AttestationGenerator,
@@ -253,7 +252,7 @@ impl std::fmt::Debug for AttestedTlsClient {
 
 impl AttestedTlsClient {
     /// Start with optional TLS client auth
-    pub async fn new(
+    pub fn new(
         cert_and_key: Option<TlsCertAndKey>,
         attestation_generator: AttestationGenerator,
         attestation_verifier: AttestationVerifier,
@@ -289,13 +288,12 @@ impl AttestedTlsClient {
             attestation_verifier,
             cert_and_key.map(|c| c.cert_chain),
         )
-        .await
     }
 
     /// Create a new proxy client with given TLS configuration
     ///
     /// This allows dangerous configuration but is used in tests
-    pub async fn new_with_tls_config(
+    pub fn new_with_tls_config(
         mut client_config: ClientConfig,
         attestation_generator: AttestationGenerator,
         attestation_verifier: AttestationVerifier,
@@ -457,8 +455,7 @@ pub async fn get_tls_cert(
         AttestationGenerator::with_no_attestation(),
         attestation_verifier,
         remote_certificate,
-    )
-    .await?;
+    )?;
     attested_tls_client
         .get_tls_cert(&host_to_host_with_port(&server_name))
         .await
@@ -476,8 +473,7 @@ pub async fn get_tls_cert_with_config(
         AttestationGenerator::with_no_attestation(),
         attestation_verifier,
         None,
-    )
-    .await?;
+    )?;
     attested_tls_client.get_tls_cert(server_name).await
 }
 
@@ -616,7 +612,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -634,7 +629,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let (_stream, _measurements, _attestation_type) =
@@ -654,7 +648,6 @@ mod tests {
             AttestationGenerator::with_no_attestation(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -672,7 +665,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let client_result = client.connect_tcp(&server_addr.to_string()).await;
@@ -696,7 +688,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -739,7 +730,6 @@ mod tests {
             attestation_verifier,
             None,
         )
-        .await
         .unwrap();
 
         let client_result = client.connect_tcp(&server_addr.to_string()).await;

--- a/attested-tls/src/websockets.rs
+++ b/attested-tls/src/websockets.rs
@@ -138,7 +138,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let ws_server = AttestedWsServer::new("127.0.0.1:0", server, None)
@@ -163,7 +162,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let ws_client: AttestedWsClient = client.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,7 @@ impl ProxyServer {
             attestation_generator,
             attestation_verifier,
             client_auth,
-        )
-        .await?;
+        )?;
 
         let listener = TcpListener::bind(local).await?;
 
@@ -120,8 +119,7 @@ impl ProxyServer {
             server_config,
             attestation_generator,
             attestation_verifier,
-        )
-        .await?;
+        )?;
 
         let listener = TcpListener::bind(local).await?;
 
@@ -331,8 +329,7 @@ impl ProxyClient {
             attestation_generator,
             attestation_verifier,
             remote_certificate,
-        )
-        .await?;
+        )?;
 
         Self::new_with_inner(address, attested_tls_client, &server_name).await
     }
@@ -362,8 +359,7 @@ impl ProxyClient {
             attestation_generator,
             attestation_verifier,
             cert_chain,
-        )
-        .await?;
+        )?;
 
         Self::new_with_inner(address, attested_tls_client, &target_name).await
     }
@@ -1324,7 +1320,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/src/self_signed.rs
+++ b/src/self_signed.rs
@@ -226,7 +226,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -246,7 +245,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let (_stream, _measurements, _attestation_type) =
@@ -280,7 +278,6 @@ mod tests {
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             AttestationVerifier::expect_none(),
         )
-        .await
         .unwrap();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -306,7 +303,6 @@ mod tests {
             AttestationVerifier::mock(),
             None,
         )
-        .await
         .unwrap();
 
         let client_tcp_stream = tokio::net::TcpStream::connect(&server_addr).await.unwrap();


### PR DESCRIPTION
The constructors of `AttestedTlsClient` and `AttestedTlsServer` are async but they do not need to be.

This PR makes them synchronous.
